### PR TITLE
fix: pass baseUrl to octokit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ async function getAuthOptionsForInstallationId(
 
   const octokit = new Octokit({
     auth: appAuth.token,
-    request,
+    baseUrl: request?.endpoint.DEFAULTS.baseUrl,
   });
 
   try {


### PR DESCRIPTION
It seems that passing `request` to octokit doesn't change the baseUrl. Instead, use the `baseUrl` option, set to the baseUrl configured in `request`