### PR TITLE
ci: drop Node.js v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ workflows:
                 - 20.2.0
                 - 18.17.0
                 - 16.20.1
-                - 14.21.3
       - cfa/release:
           requires:
             - test


### PR DESCRIPTION
Unblocks https://github.com/electron/github-app-auth/pull/15.

CircleCI has switched executors from MacOS / [Medium Gen2](https://circleci.com/docs/2.0/configuration-reference/#resourceclass) to MacOS / [M1 Medium](https://circleci.com/docs/2.0/configuration-reference/#resourceclass) - Node.js v14 does not release an arm64 version and therefore does not work anymore.